### PR TITLE
Custom serialization for TaylorInterpolant

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PlanetaryEphemeris"
 uuid = "d83715d0-7e5f-11e9-1a59-4137b20d8363"
 authors = ["Jorge A. Pérez Hernández", "Luis Benet", "Luis Eduardo Ramírez Montoya"]
-version = "0.4.0"
+version = "0.5.0"
 
 [deps]
 ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The current version of this package may be installed in Julia pkg manager via:
 
 ## Usage
 
-`PlanetaryEphemeris.propagate_dense` is a high-level function which performs the
+`PlanetaryEphemeris.propagate` is a high-level function which performs the
 numerical integration. The file `integrate_ephemeris.jl` in the `scripts` directory
 contains an example script. This script may be called as:
 

--- a/src/interpolation.jl
+++ b/src/interpolation.jl
@@ -1,4 +1,4 @@
-# This file is part of the TaylorIntegration.jl package; MIT licensed
+# This file is part of the PlanetaryEphemeris.jl package; MIT licensed
 
 @doc raw"""
     TaylorInterpolant{T, U, N}
@@ -81,6 +81,11 @@ function getinterpindex(tinterp::TaylorInterpolant{T, U, N}, t::V) where {T<:Rea
     return ind, Δt
 end
 
+@doc raw"""
+    numberofbodies(interp::TaylorInterpolant{T, U, 2}) where {T, U}
+
+Return the number of bodies saved in a `TaylorInterpolant` produced by `PlanetaryEphemeris`. 
+"""
 numberofbodies(L::Int) = (L - 13) ÷ 6
 numberofbodies(v::Vector{T}) where {T} = numberofbodies(length(v))
 numberofbodies(m::Matrix{T}) where {T} = numberofbodies(size(m, 2))
@@ -197,3 +202,81 @@ function auday2kmsec(pv)
     pv[4:6] /= daysec # (km, km/day) -> (km, km/sec)
     return pv
 end
+
+# Custom serialization 
+
+@doc raw"""
+    PlanetaryEphemerisSerialization{T}
+
+Custom serialization struct to save a `TaylorInterpolant{T, T, 2}` to a `.jld2` file. 
+
+# Fields
+- `order::Int`: order of Taylor polynomials.
+- `dims::Tuple{Int, Int}`: matrix dimensions. 
+- `t0::T`: initial time.
+- `t::Vector{T}`: vector of times. 
+- `x::Vector{T}`: vector of coefficients. 
+"""
+struct PlanetaryEphemerisSerialization{T}
+    order::Int
+    dims::Tuple{Int, Int}
+    t0::T
+    t::Vector{T}
+    x::Vector{T}
+end 
+
+# Tell JLD2 to save TaylorInterpolant{T, T, 2} as PlanetaryEphemerisSerialization{T}
+writeas(::Type{TaylorInterpolant{T, T, 2}}) where {T} = PlanetaryEphemerisSerialization{T}
+
+# Convert method to write .jld2 files
+function convert(::Type{PlanetaryEphemerisSerialization{T}}, eph::TaylorInterpolant{T, T, 2}) where {T}
+    # Taylor polynomials order
+    order = eph.x[1, 1].order
+    # Number of coefficients in each polynomial
+    k = order + 1
+    # Matrix dimensions
+    dims = size(eph.x)
+    # Number of elements in matrix
+    N = dims[1] * dims[2]
+    # Vector of coefficients 
+    x = Vector{T}(undef, k * N)
+    # Save coefficients 
+    for i in 1:N
+        x[(i-1)*k+1 : i*k] = eph.x[i].coeffs
+    end 
+
+    return PlanetaryEphemerisSerialization{T}(order, dims, eph.t0, eph.t, x)
+end 
+
+# Convert method to read .jld2 files
+function convert(::Type{TaylorInterpolant{T, T, 2}}, eph::PlanetaryEphemerisSerialization{T}) where {T} 
+    # Taylor polynomials order
+    order = eph.order
+    # Number of coefficients in each polynomial
+    k = order + 1
+    # Matrix dimensions
+    dims = eph.dims
+    # Number of elements in matrix
+    N = dims[1] * dims[2] 
+    # Matrix of Taylor polynomials 
+    x = Matrix{Taylor1{T}}(undef, dims[1], dims[2])
+    # Reconstruct Taylor polynomials 
+    for i in 1:N
+        x[i] = Taylor1{T}(eph.x[(i-1)*k+1 : i*k], order)
+    end 
+
+    return TaylorInterpolant{T, T, 2}(eph.t0, eph.t, x)
+end 
+
+@doc raw"""
+    Taylor1Serialization{T}
+
+Custom serialization struct used in previous versions (<= 0.4) of `PlanetaryEphemeris`. Currently, it is only used to 
+read old `.jld2` files. 
+"""
+struct Taylor1Serialization{T}
+    x::Vector{T}
+end
+
+# Convert method to read .jld2 files
+convert(::Type{Taylor1{T}}, a::Taylor1Serialization{T}) where {T} = Taylor1{T}(a.x, length(a.x) - 1)

--- a/src/propagation.jl
+++ b/src/propagation.jl
@@ -1,20 +1,4 @@
 @doc raw"""
-    Taylor1Serialization{T}
-
-Specialized struct to save `Taylor1{T}` objects to `.jld2` files.
-"""
-struct Taylor1Serialization{T}
-    x::Vector{T}
-end
-
-# Tell JLD2 to save Taylor1{T} as Taylor1Serialization{T}
-writeas(::Type{Taylor1{T}}) where {T} = Taylor1Serialization{T}
-# Convert method to write .jld2 files
-convert(::Type{Taylor1Serialization{T}}, a::Taylor1{T}) where {T} = Taylor1Serialization{T}(a.coeffs)
-# Convert method to read .jld2 files
-convert(::Type{Taylor1{T}}, a::Taylor1Serialization{T}) where {T} = Taylor1{T}(a.x, length(a.x) - 1)
-
-@doc raw"""
     selecteph2jld2(sseph::TaylorInterpolant, bodyind::T, tspan::S, N::Int) where {T <: AbstractVector{Int}, S <: Number}
 
 Save the ephemeris, contained in `sseph`, of the bodies with indices `bodyind`, in a `.jld2` file named as follows


### PR DESCRIPTION
This PR introduces a more efficient way to save the integration results to `.jld2` files. As a comparision, I considered a 100 years integration file:
- Before this PR: 923 MB.
- After this PR: 570 MB.