### PR TITLE
`zero(::TaylorInterpolant)`

### DIFF
--- a/src/PlanetaryEphemeris.jl
+++ b/src/PlanetaryEphemeris.jl
@@ -19,7 +19,7 @@ using DelimitedFiles
 using JLD2
 using Quadmath
 
-import Base: convert, reverse, show, join
+import Base: convert, reverse, show, join, zero, iszero
 import Dates: julian2datetime
 import JLD2: writeas
 

--- a/src/interpolation.jl
+++ b/src/interpolation.jl
@@ -40,6 +40,15 @@ function TaylorInterpolant(t0::T, t::SubArray{T, 1}, x::SubArray{Taylor1{U}, N})
     return TaylorInterpolant{T, U, N}(t0, t, x)
 end
 
+# Definition of zero TaylorInterpolant
+function zero(::Type{TaylorInterpolant{T, U, N, VT, X}}) where {T <: Number, U <: Number, N, VT <: AbstractVector{T}, X <: AbstractArray{Taylor1{U}, N}}
+    return TaylorInterpolant(zero(T), zeros(T, 1), Array{Taylor1{U}, N}(undef, zeros(Int, N)...))
+end
+
+function iszero(x::TaylorInterpolant{T, U, N, VT, X}) where {T <: Number, U <: Number, N, VT <: AbstractVector{T}, X <: AbstractArray{Taylor1{U}, N}}
+    return x == zero(TaylorInterpolant{T, U, N, VT, X})
+end
+
 # Custom print
 function show(io::IO, interp::T) where {U, V, N, T<:TaylorInterpolant{U,V,N}}
     t_range = minmax(interp.t0 + interp.t[1], interp.t0 + interp.t[end])

--- a/test/propagation.jl
+++ b/test/propagation.jl
@@ -65,7 +65,7 @@ using LinearAlgebra: norm
         U = TaylorN{T}
         @test iszero(zero(TaylorInterpolant{T, T, 2, Vector{T}, Matrix{Taylor1{T}}}))
         @test iszero(zero(TaylorInterpolant{T, U, 2, Vector{T}, Matrix{Taylor1{U}}}))
-        @test iszero(zero(TaylorInterpolant{T, U, 2, SubArray{T, 1}, SubArray{Taylor1{U}, 2}}))
+        @test iszero(zero(TaylorInterpolant{T, T, 2, SubArray{T, 1}, SubArray{Taylor1{T}, 2}}))
         @test iszero(zero(TaylorInterpolant{T, U, 2, SubArray{T, 1}, SubArray{Taylor1{U}, 2}}))
         # Test integration
         sol = propagate(5, jd0, nyears, dense; dynamics=PlanetaryEphemeris.trivialdynamics!, order, abstol)

--- a/test/propagation.jl
+++ b/test/propagation.jl
@@ -60,6 +60,13 @@ using LinearAlgebra: norm
     end
 
     @testset "TaylorInterpolant" begin
+        # Test zero TaylorInterpolant
+        T = Float64
+        U = TaylorN{T}
+        @test iszero(zero(TaylorInterpolant{T, T, 2, Vector{T}, Matrix{Taylor1{T}}}))
+        @test iszero(zero(TaylorInterpolant{T, U, 2, Vector{T}, Matrix{Taylor1{U}}}))
+        @test iszero(zero(TaylorInterpolant{T, U, 2, SubArray{T, 1}, SubArray{Taylor1{U}, 2}}))
+        @test iszero(zero(TaylorInterpolant{T, U, 2, SubArray{T, 1}, SubArray{Taylor1{U}, 2}}))
         # Test integration
         sol = propagate(5, jd0, nyears, dense; dynamics=PlanetaryEphemeris.trivialdynamics!, order, abstol)
         @test sol isa TaylorInterpolant{Float64,Float64,2}


### PR DESCRIPTION
The upcoming changes in [NEOs](https://github.com/PerezHz/NEOs.jl/pull/31) require a `zero(::TaylorInterpolant)` method and, as @PerezHz pointed out, it'd better to have that definition here. 