### PR TITLE
Fix `selecteph`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PlanetaryEphemeris"
 uuid = "d83715d0-7e5f-11e9-1a59-4137b20d8363"
 authors = ["Jorge A. Pérez Hernández", "Luis Benet", "Luis Eduardo Ramírez Montoya"]
-version = "0.11.2"
+version = "0.11.3"
 
 [deps]
 ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"

--- a/scripts/de430.jl
+++ b/scripts/de430.jl
@@ -103,7 +103,7 @@ function main()
 
     # Body indices in output
     bodyind::UnitRange{Int} = parsed_args["bodyind"]
-    println("• Body indices in output: ", parse_eqs)
+    println("• Body indices in output: ", bodyind)
 
     # Planetary ephemeris problem
     jd0 = datetime2julian(d0)

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -443,24 +443,19 @@ const c_p2 = 29979.063823897606                # Speed of light^2 in au^2/day^2
 const c_m2 = 3.3356611996764786e-5             # Speed of light^-2 in day^2/au^2
 const c_m4 = 1.1126635639027125e-9             # Speed of light^-4 in day^4/au^4
 
-@doc raw"""
-    nbodyind(N::Int, i::Int)
-    nbodyind(N::Int, ivec::AbstractVector{Int})
+"""
+    nbodyind(N, idxs)
 
-Return the indices of the positions and velocities of the `i`-th body (or the
-`ivec`-th bodies) in a vector with `N` bodies. The function assumes that the vector has
-the form: `3N` positions + `3N` velocities (+ Lunar physical librations + TT-TDB).
+Return the indices of the positions and velocities of the `idxs`-th bodies
+in a vector of the form:  `3N` positions + `3N` velocities + Lunar physical
+librations + TT-TDB.
 """
 nbodyind(N::Int, i::Int) = union(3i-2:3i, 3*(N+i)-2:3*(N+i))
 
-function nbodyind(N::Int, ivec::T) where {T <: AbstractVector{Int}}
-    a = Vector{Int}(undef, 0)
-    for i in ivec
-        i > N && continue
-        a = union(a, nbodyind(N, i))
-    end
-
-    return sort(a)
+function nbodyind(N::Int, idxs::AbstractVector{Int})
+    jdxs = mapreduce(Base.Fix1(nbodyind, N), vcat, idxs)
+    sort!(jdxs)
+    return sort(jdxs)
 end
 
 const sundofs = nbodyind(length(μ), su)        # Sun's position and velocity indices

--- a/src/interpolation/TaylorInterpolant.jl
+++ b/src/interpolation/TaylorInterpolant.jl
@@ -118,47 +118,47 @@ numberofbodies(interp::TaylorInterpolant) = numberofbodies(size(interp.x, 2))
 
 # Function-like (callability) methods
 
-@doc raw"""
-    (tinterp::TaylorInterpolant{T, U, 1})(t::T) where {T, U}
-    (tinterp::TaylorInterpolant{T, U, 1})(t::TT) where {T, U, TT<:TaylorInterpCallingArgs{T,U}}
-    (tinterp::TaylorInterpolant{T, U, 2})(t::T) where {T, U}
-    (tinterp::TaylorInterpolant{T, U, 2})(t::TT) where {T, U, TT<:TaylorInterpCallingArgs{T,U}}
+"""
+    (eph::TaylorInterpolant)([target [, observer] ,] t)
 
-Evaluate `tinterp.x` at time `t`.
+Evaluate `eph` at time `t`. If `target` and `observer` are given,
+return the state of `target` relative to `observer`.
 
 See also [`getinterpindex`](@ref).
 """
-function (tinterp::TaylorInterpolant{T, U, 1})(t::T) where {T, U}
-    # Get index of tinterp.x that interpolates at time t
-    ind::Int, δt::T = getinterpindex(tinterp, t)
-    # Evaluate tinterp.x[ind] at δt
-    return (tinterp.x[ind])(δt)::U
-end
-function (tinterp::TaylorInterpolant{T, U, 1})(t::TT) where {T, U, TT<:TaylorInterpCallingArgs{T,U}}
-    # Get index of tinterp.x that interpolates at time t
-    ind::Int, δt::TT = getinterpindex(tinterp, t)
-    # Evaluate tinterp.x[ind] at δt
-    return (tinterp.x[ind])(δt)::TT
+function (eph::TaylorInterpolant{T, U, 1})(t::T) where {T, U}
+    # Get index of eph.x that interpolates at time t
+    ind::Int, δt::T = getinterpindex(eph, t)
+    # Evaluate eph.x[ind] at δt
+    return (eph.x[ind])(δt)::U
 end
 
-function (tinterp::TaylorInterpolant{T, U, 2})(t::T) where {T, U}
-    # Get index of tinterp.x that interpolates at time t
-    ind::Int, δt::T = getinterpindex(tinterp, t)
-    # Evaluate tinterp.x[ind] at δt
-    return view(tinterp.x, ind, :)(δt)::Vector{U}
-end
-function (tinterp::TaylorInterpolant{T, U, 2})(t::TT) where {T, U, TT<:TaylorInterpCallingArgs{T,U}}
-    # Get index of tinterp.x that interpolates at time t
-    ind::Int, δt::TT = getinterpindex(tinterp, t)
-    # Evaluate tinterp.x[ind] at δt
-    return view(tinterp.x, ind, :)(δt)::Vector{TT}
+function (eph::TaylorInterpolant{T, U, 1})(t::TT) where {T, U, TT <: TaylorInterpCallingArgs{T, U}}
+    # Get index of eph.x that interpolates at time t
+    ind::Int, δt::TT = getinterpindex(eph, t)
+    # Evaluate eph.x[ind] at δt
+    return (eph.x[ind])(δt)::TT
 end
 
-function (tinterp::TaylorInterpolant{T, U, 2})(target::Int, observer::Int, t::T)  where {T, U}
-    # Number of bodies in tinterp
-    N = numberofbodies(tinterp)
+function (eph::TaylorInterpolant{T, U, 2})(t::T) where {T, U}
+    # Get index of eph.x that interpolates at time t
+    ind::Int, δt::T = getinterpindex(eph, t)
+    # Evaluate eph.x[ind] at δt
+    return view(eph.x, ind, :)(δt)::Vector{U}
+end
+
+function (eph::TaylorInterpolant{T, U, 2})(t::TT) where {T, U, TT <: TaylorInterpCallingArgs{T, U}}
+    # Get index of eph.x that interpolates at time t
+    ind::Int, δt::TT = getinterpindex(eph, t)
+    # Evaluate eph.x[ind] at δt
+    return view(eph.x, ind, :)(δt)::Vector{TT}
+end
+
+function (eph::TaylorInterpolant{T, U, 2})(target::Int, observer::Int, t::T)  where {T, U}
+    # Number of bodies in eph
+    N = numberofbodies(eph)
     # Ephemeris at time t
-    eph_t = tinterp(t)
+    eph_t = eph(t)
     # Relative state vector
     if observer == 0
         return eph_t[nbodyind(N, target)]
@@ -167,7 +167,8 @@ function (tinterp::TaylorInterpolant{T, U, 2})(target::Int, observer::Int, t::T)
     end
 end
 
-(tinterp::TaylorInterpolant{T,U,2})(target::Int, t::TT) where {T, U, TT<:TaylorInterpCallingArgs{T,U}} = tinterp(target, 0, t)
+(eph::TaylorInterpolant{T, U, 2})(target::Int, t::TT) where
+    {T, U, TT <: TaylorInterpCallingArgs{T, U}} = eph(target, 0, t)
 
 @doc raw"""
     reverse(tinterp::TaylorInterpolant{T,U,N}) where {T<:Real, U<:Number, N}

--- a/src/interpolation/TaylorInterpolant.jl
+++ b/src/interpolation/TaylorInterpolant.jl
@@ -50,19 +50,17 @@ function iszero(x::TaylorInterpolant{T, U, N, VT, X}) where {T <: Number, U <: N
 end
 
 # Custom print
-function show(io::IO, interp::T) where {U, V, N, T<:TaylorInterpolant{U,V,N}}
-    t_range = minmax(interp.t0 + interp.t[1], interp.t0 + interp.t[end])
-    S = eltype(interp.x)
-    if isone(N)
-        print(io, "t: ", t_range, ", x: 1 ", S, " variable")
-    else
-        L = size(interp.x, 2)
-        print(io, "t: ", t_range, ", x: ", L, " ", S, " variables")
-    end
+function show(io::IO, x::TaylorInterpolant)
+    tspan = timespan(x)
+    L = last(size(x.x))
+    S = eltype(x.x)
+    print(io, "t: ", tspan, ", x: ", L, " ", S, " variable(s)")
 end
 
 # Override get_order
 get_order(x::TaylorInterpolant) = get_order(first(x.x))
+
+timespan(x::TaylorInterpolant) = minmax(x.t0 + x.t[1], x.t0 + x.t[end])
 
 @doc raw"""
     convert(::Type{T}, interp::TaylorInterpolant) where {T <: Real}
@@ -206,38 +204,41 @@ function flipsign(eph::TaylorInterpolant)
     return TaylorInterpolant(eph.t0, t, x)
 end
 
-@doc raw"""
-    selecteph(eph::TaylorInterpolant, bodyind::Union{Int, AbstractVector{Int}}, t0::T = eph.t0,
-              tf::T = eph.t0 + eph.t[end]; euler::Bool = false, ttmtdb::Bool = false) where {T <: Real}
-
-Return a subset of `eph` with only the ephemeris of bodies `bodyind` in timerange `[t0, tf]`.
-The keyword arguments allow to include lunar euler angles and/or TT-TDB.
 """
-function selecteph(eph::TaylorInterpolant, bodyind::Union{Int, AbstractVector{Int}}, t0::T = eph.t0,
-                   tf::T = eph.t0 + eph.t[end]; euler::Bool = false, ttmtdb::Bool = false) where {T <: Real}
-    # Times
-    tmin, tmax = minmax(eph.t0, eph.t0 + eph.t[end])
-    @assert tmin ≤ t0 ≤ tf ≤ tmax "$tmin ≤ t0 ≤ tf ≤ $tmax"
-    if issorted(eph.t)
-        i_0 = searchsortedlast(eph.t, t0)
-        i_f = searchsortedfirst(eph.t, tf)
-    else
-        i_0 = searchsortedlast(eph.t, tf, rev = true)
-        i_f = searchsortedfirst(eph.t, t0, rev = true)
-    end
-    # Degrees of freedom
+    selecteph(eph::TaylorInterpolant, bodyind [, t0, tf]; kwargs...)
+
+Return a subset of `eph` containing only the ephemeris of the `bodyind`-th
+bodies and spanning `[t0, tf]`.
+
+# Keyword arguments
+
+- `euler::Bool`: whether to include lunar euler angles (default: `false`).
+- `ttmtdb::Bool`: whether to include TT-TDB (default: `false`).
+"""
+function selecteph(eph::TaylorInterpolant, bodyind::Union{Int, AbstractVector{Int}},
+                   t0::T = eph.t0, tf::T = eph.t0 + eph.t[end]; euler::Bool = false,
+                   ttmtdb::Bool = false) where {T <: Real}
+    # Check whether arguments are compatible with eph
+    tmin, tmax = timespan(eph)
+    @assert tmin ≤ t0 < tf ≤ tmax "$tmin ≤ t0 ≤ tf ≤ $tmax"
     N = numberofbodies(eph)
-    @assert all(bodyind .< N) "bodyind .< $N"
-    idxs = nbodyind(N, bodyind)
+    @assert all(≤(N), bodyind) "All bodyind must be smaller than $N"
+    # Which columns of eph.x to keep
+    cols = nbodyind(N, bodyind)
     if euler
-        idxs = vcat(idxs, 6N+1:6N+12)
+        cols = vcat(cols, 6N+1:6N+12)
     end
     if ttmtdb
-        idxs = vcat(idxs, 6N+13)
+        cols = vcat(cols, 6N+13)
     end
     # Views
-    t = view(eph.t, i_0:i_f)
-    x = view(eph.x, i_0:i_f-1, idxs)
+    dt0, dtf = minmax(abs(t0 - eph.t0), abs(tf - eph.t0))
+    j0, jf = minmax(
+        searchsortedlast(eph.t, dt0, by = abs),
+        searchsortedfirst(eph.t, dtf, by = abs)
+    )
+    t = view(eph.t, j0:jf)
+    x = view(eph.x, j0:jf-1, cols)
     # New TaylorInterpolant
     return TaylorInterpolant(eph.t0, t, x)
 end

--- a/src/propagation.jl
+++ b/src/propagation.jl
@@ -69,22 +69,20 @@ function loadeph(ss16asteph::TaylorInterpolant, μ::Vector{<:Real})
     return acc_eph, pot_eph
 end
 
-@doc raw"""
-    selecteph2jld2(sseph::TaylorInterpolant, bodyind::T, tspan::S) where {T <: AbstractVector{Int}, S <: Number}
-
-Save the ephemeris, contained in `sseph`, of the bodies with indices `bodyind`, in a `.jld2` file named as follows
-
-    "sseph" * number of asteroids in sseph * "ast" * number of asteroids to be saved in file * "_"
-    * "p" / "m" (forward / backward integration) * number of years in sseph *  "y_et.jld2"
-
-# Arguments
-
-- `sseph::TaylorInterpolant`: ephemeris of all the bodies.
-- `bodyind::T`: indices of the bodies to be saved.
-- `tspan::S`: time span of the integration (positive -> forward integration / negative -> backward integration).
 """
-function selecteph2jld2(sseph::TaylorInterpolant, bodyind::T, tspan::S) where {T <: AbstractVector{Int}, S <: Number}
+    selecteph2jld2(sseph::TaylorInterpolant, bodyind, nyears)
 
+Save a subset of `sseph` containing only the ephemeris of the
+`bodyind`-th bodies in a `.jld2` file named as follows
+
+    sseph{N}ast{n}_{p/m}{nyears}y_et.jld2
+
+where `N` is the number of asteroids in sseph, `n` is the number
+of asteroids to be saved in the file, `p/m` indicates a forward
+or backward integration and `nyears` is the number of years.
+"""
+function selecteph2jld2(sseph::TaylorInterpolant, bodyind::AbstractVector{Int},
+                        nyears::Number)
     # Total number of bodies
     N = numberofbodies(sseph)
     # Number of asteroids in sseph
@@ -92,27 +90,21 @@ function selecteph2jld2(sseph::TaylorInterpolant, bodyind::T, tspan::S) where {T
     # Number of asteroids to be saved
     nastout = length(bodyind) - 11
     # Check nastout <= nast
-    @assert nastout <= nast "Cannot save $nastout asteroids from ephemeris with $nast asteroids"
+    @assert nastout <= nast "Cannot save $nastout asteroids from ephemeris \
+        with $nast asteroids"
     # Prefix to distinguish between forward (p) / backward (m) integration
-    sgn_yrs = signbit(tspan) ? "m" : "p"
+    sgn_yrs = signbit(nyears) ? "m" : "p"
     # Number of years
-    nyrs_int = floor(Int, abs(tspan))
-
-    # Write output to .jld2 file
-
+    nyrs_int = floor(Int, abs(nyears))
     # Name of the file
-    ss16ast_fname = "sseph$(lpad(nast,3,'0'))ast$(lpad(nastout,3,'0'))_" * sgn_yrs * "$(nyrs_int)y_et.jld2"
-
-    # TaylorInterpolant with only the information of the bodies to be saved + Lunar orientation + TT-TDB
-    ss16ast_eph = selecteph(sseph, bodyind, euler = true, ttmtdb = true)
-
-    println("Saving solution to file: ", ss16ast_fname)
-
+    ss16ast_fname = "sseph$(lpad(nast,3,'0'))ast$(lpad(nastout,3,'0'))_" *
+        sgn_yrs * "$(nyrs_int)y_et.jld2"
+    # Select bodies to be saved + Lunar orientation + TT-TDB
+    t0, tf = timespan(sseph)
+    ss16ast_eph = selecteph(sseph, bodyind, t0, tf, euler = true, ttmtdb = true)
     # Open file
-    JLD2.jldopen(ss16ast_fname, "w") do file
-        # Write the ephemeris to file
-        write(file, "ss16ast_eph", ss16ast_eph)
-    end
+    println("Saving solution to file: ", ss16ast_fname)
+    jldsave(ss16ast_fname; ss16ast_eph)
     # Check that written output is equal to original variable ss16ast_eph
     recovered_sol_i = JLD2.load(ss16ast_fname, "ss16ast_eph")
     if recovered_sol_i == ss16ast_eph

--- a/test/propagation.jl
+++ b/test/propagation.jl
@@ -133,12 +133,34 @@ end
         sol = propagate(PP; order, abstol)
 
         @test isa(string(PP), String)
-        @test sol isa TaylorInterpolant{T, T, 2}
-        @test sol(sol.t0) == q0
+        @test isa(string(sol), String)
+        @test isa(sol, TaylorInterpolant{T, T, 2})
+        @test isa(PP, PlanetaryEphemerisProblem{typeof(freeparticle!), T, Tuple{Int64, T}})
         @test sol.t0 == 0.0
         @test sol.t[end] == nyears * yr
         @test length(sol.t) == size(sol.x, 1) + 1
         @test length(q0) == size(sol.x, 2)
+        @test numberofbodies(size(sol.x, 2)) == numberofbodies(sol.x[1, :]) ==
+              numberofbodies(sol.x) == numberofbodies(sol) == N
+
+        # Evaluation
+        t = Taylor1(order)
+        @test sol(sol.t0) == q0
+        @test constant_term(sol(t)) == q0
+        @test all(iszero, sol(1, 1, sol.t0))
+        @test sol(1, sol.t0) == q0[nbodyind(N, 1)]
+
+        # Convert
+        sol128 = convert(Float128, sol)
+        @test sol128.t0 == Float128(sol.t0)
+        @test sol128.t == Float128.(sol.t)
+        @test all(@. constant_term(sol128.x) == Float128(constant_term(sol.x)))
+
+        # Reverse
+        solrev = reverse(sol)
+        @test solrev.t0 == sol.t0 + sol.t[end]
+        @test solrev.t == -sol.t
+        @test solrev(solrev.t0 + solrev.t[end]) ≈ sol(sol.t0)
 
         dq = TaylorSeries.set_variables("dq", order = 2, numvars = 2)
         tmid = sol.t0 + sol.t[2] / 2


### PR DESCRIPTION
I've discovered that `selecteph` throws an error if the interpolant's initial time is negative. This PR fixes such error.